### PR TITLE
Add Virtual Charger (browser-only OCPP 1.6J/2.0.1/2.1 simulator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ The **Open InterCharge Protocol (OICP)** is another protocol for roaming, develo
 **HTML**
 * [JavaIsJavaScript/OCPP-J-CP-Simulator](https://github.com/JavaIsJavaScript/OCPP-J-CP-Simulator) (HTML; OCPP 1.6; A really simple cp simulator, that works with OCPP 1.6)
 * [victormunoz/OCPP-1.6-Chargebox-Simulator](https://github.com/victormunoz/OCPP-1.6-Chargebox-Simulator) (HTML; OCPP 1.6; A simple chargepoint simulator, working with OCPP 1.6)
+* [Virtual Charger](https://virtualcharger.app) (HTML; OCPP 1.6J, OCPP 2.0.1, OCPP 2.1; Browser-only virtual EVSE for testing CSMS/CPMS integrations — no install or backend. SmartCharging, multi-EVSE power sharing, dual-head DC topology, offline session & OCPP log replay.)
 
 **Java**
 * [evbox/station-simulator](https://github.com/evbox/station-simulator) (Java)


### PR DESCRIPTION
Adds **Virtual Charger** to the OCPP simulators list (Simulators → HTML).

It's a browser-only virtual EVSE that speaks **OCPP 1.6J, 2.0.1 and 2.1** to any compliant CSMS — no install, no build step, no backend. Aimed at QA engineers and developers testing EMP ↔ CPMS integrations without physical hardware.

Features: full SmartCharging (charging-profile resolution + live power chart), multi-EVSE topology with sibling locking and FCFS power sharing, dual-head DC station simulation, offline session replay, and OCPP wire-level log replay.

Demo: https://virtualcharger.app

Note: it's a hosted live demo (closed source for now) rather than a repo — happy to adjust the placement, wording, or format if you'd prefer it elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Virtual Charger simulator to the available OCPP simulators, including supported OCPP versions and browser-only testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->