### PR TITLE
docs: OCPP 1.6 configuration keys page and OCPI 2.3.0 modules rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,16 +78,68 @@ The **Open Charge Point Interface (OCPI)** is a protocol for roaming between cha
 
 #### Modules
 
-- [Direct Payment](https://evroaming.org/wp-content/uploads/2024/10/DirectPayment_2_2_1___EVRF_version.pdf) (2.2.1, 2024-03)
-- [e-PoI service](https://www.gireve.com/wp-content/uploads/2025/10/Gireve_Tech_ePoI-OCPI-2.2.1_ImplementationGuide_V1.1-_en.pdf) (2.2.1, Gireve, 2025-10)
-- [Accessibility extension](https://evroaming.org/wp-content/uploads/2026/01/e_accessibility_extension-1.0.0.pdf) (2.3.0, 3.0, 2025-12)
-- Booking (2.3.0)
-  - [ed2](https://github.com/ocpi/ocpi/releases/download/v2.3.0-bookings/OCPI-2.3.0-bookings.pdf) (2026-06)
-  - [1.1](https://evroaming.org/wp-content/uploads/2026/01/OCPI-2.3.0-booking-1.1.pdf) (2025-06)
+OCPI 2.3.0 is published as a [core specification](https://github.com/ocpi/ocpi/tree/2.3.0/release/core) plus optional modules packaged separately.
+
+Core functional modules:
+
+| Module                 | Specification per version                                           |
+| ---------------------- | ------------------------------------------------------------------- |
+| Locations              | [2.1.1][ocpi-loc-211], [2.2.1][ocpi-loc-221], [2.3.0][ocpi-loc-230] |
+| Sessions               | [2.1.1][ocpi-ses-211], [2.2.1][ocpi-ses-221], [2.3.0][ocpi-ses-230] |
+| CDRs                   | [2.1.1][ocpi-cdr-211], [2.2.1][ocpi-cdr-221], [2.3.0][ocpi-cdr-230] |
+| Tariffs                | [2.1.1][ocpi-tar-211], [2.2.1][ocpi-tar-221], [2.3.0][ocpi-tar-230] |
+| Tokens                 | [2.1.1][ocpi-tok-211], [2.2.1][ocpi-tok-221], [2.3.0][ocpi-tok-230] |
+| Commands               | [2.1.1][ocpi-cmd-211], [2.2.1][ocpi-cmd-221], [2.3.0][ocpi-cmd-230] |
+| Charging Profiles      | [2.2.1][ocpi-cp-221], [2.3.0][ocpi-cp-230]                          |
+| Hub Client Info        | [2.2.1][ocpi-hci-221], [2.3.0][ocpi-hci-230]                        |
+| Invoice Reconciliation | [2.3.0 (ed2)][ocpi-ir-230]                                          |
+
+Additional modules (packaged separately). Payments and Bookings are optional, evolve independently of the core, and are published as standalone PDFs bundling a core edition with the module. They are independent from each other and from Invoice Reconciliation — an implementation may support any of them on its own.
+
 - Payments (2.3.0)
-  - [ed2](https://github.com/ocpi/ocpi/releases/download/v2.3.0-ed2-payments/OCPI-2.3.0-ed2-payments.pdf) (2026-06, adds invoice reconciliation)
-  - [ed1](https://github.com/ocpi/ocpi/releases/download/v2.3.0-payments/OCPI-2.3.0-payments.pdf) (2026-06)
-- [Autocharge](https://ocpi.fyi/ocpi/2.3.0/extensions/mod_autocharge_roaming.html) (2.3.0, community)
+  - [ed2](https://github.com/ocpi/ocpi/releases/download/v2.3.0-ed2-payments/OCPI-2.3.0-ed2-payments.pdf) (2026-06, core edition 2 + Payments)
+  - [ed1](https://github.com/ocpi/ocpi/releases/download/v2.3.0-payments/OCPI-2.3.0-payments.pdf) (2026-06, core edition 1 + Payments)
+- Booking (2.3.0) — exact version labels are still being settled; the OCPI editors deferred on this in [ocpi/ocpi#572](https://github.com/ocpi/ocpi/issues/572)
+  - ed2 — not yet released
+  - [ed1](https://github.com/ocpi/ocpi/releases/download/v2.3.0-bookings/OCPI-2.3.0-bookings.pdf) (2026-06, tag `v2.3.0-bookings`)
+  - [1.1](https://evroaming.org/wp-content/uploads/2026/01/OCPI-2.3.0-booking-1.1.pdf) (2025-06, no GitHub tag)
+
+Extensions (vendor / community):
+
+| Extension                          | OCPI version | Source    | Date    |
+| ---------------------------------- | ------------ | --------- | ------- |
+| [Direct Payment][ext-dp]           | 2.2.1        | EVRoaming | 2024-03 |
+| [e-PoI service][ext-epoi]          | 2.2.1        | Gireve    | 2025-10 |
+| [Accessibility extension][ext-acc] | 2.3.0, 3.0   | EVRoaming | 2025-12 |
+| [Autocharge][ext-ac]               | 2.3.0        | Community | —       |
+
+[ocpi-loc-211]: https://github.com/ocpi/ocpi/blob/release-2.1.1-bugfixes/mod_locations.md
+[ocpi-loc-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_locations.asciidoc
+[ocpi-loc-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_locations.asciidoc
+[ocpi-ses-211]: https://github.com/ocpi/ocpi/blob/release-2.1.1-bugfixes/mod_sessions.md
+[ocpi-ses-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_sessions.asciidoc
+[ocpi-ses-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_sessions.asciidoc
+[ocpi-cdr-211]: https://github.com/ocpi/ocpi/blob/release-2.1.1-bugfixes/mod_cdrs.md
+[ocpi-cdr-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_cdrs.asciidoc
+[ocpi-cdr-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_cdrs.asciidoc
+[ocpi-tar-211]: https://github.com/ocpi/ocpi/blob/release-2.1.1-bugfixes/mod_tariffs.md
+[ocpi-tar-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_tariffs.asciidoc
+[ocpi-tar-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_tariffs.asciidoc
+[ocpi-tok-211]: https://github.com/ocpi/ocpi/blob/release-2.1.1-bugfixes/mod_tokens.md
+[ocpi-tok-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_tokens.asciidoc
+[ocpi-tok-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_tokens.asciidoc
+[ocpi-cmd-211]: https://github.com/ocpi/ocpi/blob/release-2.1.1-bugfixes/mod_commands.md
+[ocpi-cmd-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_commands.asciidoc
+[ocpi-cmd-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_commands.asciidoc
+[ocpi-cp-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_charging_profiles.asciidoc
+[ocpi-cp-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_charging_profiles.asciidoc
+[ocpi-hci-221]: https://github.com/ocpi/ocpi/blob/release-2.2.1-bugfixes/mod_hub_client_info.asciidoc
+[ocpi-hci-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_hub_client_info.asciidoc
+[ocpi-ir-230]: https://github.com/ocpi/ocpi/blob/2.3.0/release/core/mod_invoice_reconciliation.asciidoc
+[ext-dp]: https://evroaming.org/wp-content/uploads/2024/10/DirectPayment_2_2_1___EVRF_version.pdf
+[ext-epoi]: https://www.gireve.com/wp-content/uploads/2025/10/Gireve_Tech_ePoI-OCPI-2.2.1_ImplementationGuide_V1.1-_en.pdf
+[ext-acc]: https://evroaming.org/wp-content/uploads/2026/01/e_accessibility_extension-1.0.0.pdf
+[ext-ac]: https://ocpi.fyi/ocpi/2.3.0/extensions/mod_autocharge_roaming.html
 
 #### Roaming
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The **Open Charge Point Protocol (OCPP)** is a communication protocol between el
   - [1.x - Multiple Connectors per EVSE](https://github.com/juherr/awesome-ev-charging/blob/main/ocpp/Whitepapers/ocpp_1_x_multiple_connectors_per_evse.pdf)
   - [1.5 (deprecated)](https://github.com/juherr/awesome-ev-charging/tree/main/ocpp/OCPP-1.5) (2012)
   - [1.2 (deprecated)](https://github.com/juherr/awesome-ev-charging/tree/main/ocpp/OCPP-1.2) (2010)
+- [Configuration Keys (1.6)](https://github.com/juherr/awesome-ev-charging/blob/main/ocpp/OCPP-1.6-configuration-keys.md) - Reference table of OCPP 1.6 configuration keys.
 
 ### ISO 15118
 

--- a/ocpp/OCPP-1.6-configuration-keys.md
+++ b/ocpp/OCPP-1.6-configuration-keys.md
@@ -1,0 +1,97 @@
+# OCPP 1.6 Configuration Keys
+
+Reference of the OCPP 1.6 configuration keys, grouped by feature profile (plus the
+OCPP-J transport keys and the Security extension from the OCPP 1.6 Security Whitepaper,
+ext 1.3).
+
+The **Required / Optional** column reflects the OCPP 1.6 specification (edition 2) and
+the Security Whitepaper (edition 3): "Required" means the Charge Point must support the
+key when it implements the corresponding profile.
+
+## Legend
+
+- **CSL** = Comma Separated List
+- **R** = Read-only
+- **RW** = Read-Write
+- **W** = Write-only
+- **Required / Optional** = whether supporting the key is mandatory for the profile
+
+## Core Profile
+
+| Key | Required/Optional | Accessibility | Type |
+|---|---|---|---|
+| AllowOfflineTxForUnknownId | Optional | RW | boolean |
+| AuthorizationCacheEnabled | Optional | RW | boolean |
+| AuthorizeRemoteTxRequests | Required | RW | boolean |
+| BlinkRepeat | Optional | RW | integer |
+| ClockAlignedDataInterval | Required | RW | integer |
+| ConnectionTimeOut | Required | RW | integer |
+| ConnectorPhaseRotation | Required | R | csl :<br>NotApplicable<br>Unknown<br>RST<br>RTS<br>SRT<br>STR<br>TRS<br>TSR |
+| ConnectorPhaseRotationMaxLength | Optional | R | integer |
+| GetConfigurationMaxKeys | Required | R | integer |
+| HeartbeatInterval | Required | RW | integer |
+| LightIntensity | Optional | RW | integer |
+| LocalAuthorizeOffline | Required | RW | boolean |
+| LocalPreAuthorize | Required | RW | boolean |
+| MaxEnergyOnInvalidId | Optional | R | integer |
+| MeterValueSampleInterval | Required | RW | integer |
+| MeterValuesAlignedData | Required | RW | integer |
+| MeterValuesAlignedDataMaxLength | Optional | R | integer |
+| MeterValuesSampledData | Required | RW | csl :<br>Energy.Active.Import.Register<br>Power.Active.Import<br>Current.Import<br>Voltage<br>Temperature<br>Current.Offered<br>Frequency<br>Power.Factor |
+| MeterValuesSampledDataMaxLength | Optional | R | integer |
+| MinimumStatusDuration | Optional | RW | integer |
+| NumberOfConnectors | Required | R | integer |
+| ResetRetries | Required | RW | integer |
+| StopTransactionOnEVSideDisconnect | Required | RW | boolean |
+| StopTransactionOnInvalidId | Required | RW | boolean |
+| StopTxnAlignedData | Required | R | string |
+| StopTxnAlignedDataMaxLength | Optional | R | integer |
+| StopTxnSampledData | Required | R | string |
+| StopTxnSampledDataMaxLength | Optional | R | integer |
+| SupportedFeatureProfiles | Required | R | csl :<br>Core<br>FirmwareManagement<br>LocalAuthListManagement<br>RemoteTrigger<br>Reservation<br>SmartCharging |
+| SupportedFeatureProfilesMaxLength | Optional | R | integer |
+| SupportedFileTransferProtocols | Required | R | string |
+| TransactionMessageAttempts | Required | RW | integer<br>1 - 65535<br>0 (retry indefinitely) |
+| TransactionMessageRetryInterval | Required | RW | integer |
+| UnlockConnectorOnEVSideDisconnect | Required | RW | boolean |
+
+## Smart Charging Profile
+
+| Key | Required/Optional | Accessibility | Type |
+|---|---|---|---|
+| ChargeProfileMaxStackLevel | Required | R | integer |
+| ChargingScheduleAllowedChargingRateUnit | Required | R | csl :<br>Current<br>Power |
+| ChargingScheduleMaxPeriods | Required | R | integer |
+| ConnectorSwitch3to1PhaseSupported | Optional | R | boolean |
+| MaxChargingProfilesInstalled | Required | R | integer |
+
+## Local Auth List Management Profile
+
+| Key | Required/Optional | Accessibility | Type |
+|---|---|---|---|
+| LocalAuthListEnabled | Required | RW | boolean |
+| LocalAuthListMaxLength | Required | R | integer |
+| SendLocalListMaxLength | Required | R | integer |
+
+## Reservation Profile
+
+| Key | Required/Optional | Accessibility | Type |
+|---|---|---|---|
+| ReserveConnectorZeroSupported | Optional | R | boolean |
+
+## Security Profile (OCPP ext 1.3)
+
+| Key | Required/Optional | Accessibility | Type |
+|---|---|---|---|
+| AdditionalRootCertificateCheck | Optional | R | boolean |
+| CertificateSignedMaxChainSize | Optional | R | integer |
+| CertificateStoreMaxLength | Optional | R | integer |
+| CpoName | Optional | RW | string |
+| SecurityProfile | Optional | RW | integer |
+
+## OCPP-J (transport)
+
+| Key | Required/Optional | Accessibility | Type |
+|---|---|---|---|
+| AuthorizationKey | Optional | W | string |
+| WebSocketPingInterval | Optional | RW | integer |


### PR DESCRIPTION
## Summary

Two documentation changes to the reference sections of the awesome list. Both edits are hand-authored and stay outside the pipeline-generated markers.

### `docs(ocpp)` — OCPP 1.6 configuration keys reference page
- New `ocpp/OCPP-1.6-configuration-keys.md`, grouped by feature profile (Core, Smart Charging, Local Auth List Management, Reservation, Security ext 1.3, OCPP-J transport).
- Adds a **Required/Optional** column sourced from the vendored specs (OCPP 1.6 edition 2 + Security Whitepaper edition 3), replacing the earlier "(optional ?)" guesses.
- Fixes a key name: `CertificateSignedMaxChain` → `CertificateSignedMaxChainSize` (whitepaper §7.3); casing `HeartbeatInterval`.
- Linked from the OCPP section of the README.

### `docs(ocpi)` — modules section reworked against the 2.3.0 core spec
- Core functional modules as a table, each supporting version linking to **its own** spec (2.1.1 / 2.2.1 bugfix branches, 2.3.0/release/core); all 23 links verified.
- Separately-packaged optional modules (Payments, Bookings) with their core edition, and a vendor/community extensions table.
- Payments, Bookings and Invoice Reconciliation noted as optional and mutually independent, per the OCPI editors' answers in ocpi/ocpi#572.
- Bookings listed as its three versions (ed2 not yet released, ed1, 1.1 with no GitHub tag), most-recent-first; corrected a non-existent `v2.3.0-bookings-ed2` release reference.

## Verification
- All per-version module spec URLs return HTTP 200.
- README edits confined to lines ~44 and ~81-115; generated PROJECTS/TOC marker blocks untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive OCPP 1.6 configuration keys reference, organized by profile with accessibility and value details.
  - Updated the OCPI documentation to provide a structured overview of OCPI 2.3.0, including a core modules table and clearer separation of separately packaged modules.
  - Reworked OCPI extension documentation into a version-aware table with source and date references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->