### PR TITLE
docs(ocpp): fix 1.6 config key types and accessibility

### DIFF
--- a/ocpp/OCPP-1.6-configuration-keys.md
+++ b/ocpp/OCPP-1.6-configuration-keys.md
@@ -35,7 +35,7 @@ key when it implements the corresponding profile.
 | LocalPreAuthorize | Required | RW | boolean |
 | MaxEnergyOnInvalidId | Optional | R | integer |
 | MeterValueSampleInterval | Required | RW | integer |
-| MeterValuesAlignedData | Required | RW | integer |
+| MeterValuesAlignedData | Required | RW | csl :<br>Energy.Active.Import.Register<br>Power.Active.Import<br>Current.Import<br>Voltage<br>Temperature<br>Current.Offered<br>Frequency<br>Power.Factor |
 | MeterValuesAlignedDataMaxLength | Optional | R | integer |
 | MeterValuesSampledData | Required | RW | csl :<br>Energy.Active.Import.Register<br>Power.Active.Import<br>Current.Import<br>Voltage<br>Temperature<br>Current.Offered<br>Frequency<br>Power.Factor |
 | MeterValuesSampledDataMaxLength | Optional | R | integer |
@@ -44,9 +44,9 @@ key when it implements the corresponding profile.
 | ResetRetries | Required | RW | integer |
 | StopTransactionOnEVSideDisconnect | Required | RW | boolean |
 | StopTransactionOnInvalidId | Required | RW | boolean |
-| StopTxnAlignedData | Required | R | string |
+| StopTxnAlignedData | Required | RW | csl :<br>Energy.Active.Import.Register<br>Power.Active.Import<br>Current.Import<br>Voltage<br>Temperature<br>Current.Offered<br>Frequency<br>Power.Factor |
 | StopTxnAlignedDataMaxLength | Optional | R | integer |
-| StopTxnSampledData | Required | R | string |
+| StopTxnSampledData | Required | RW | csl :<br>Energy.Active.Import.Register<br>Power.Active.Import<br>Current.Import<br>Voltage<br>Temperature<br>Current.Offered<br>Frequency<br>Power.Factor |
 | StopTxnSampledDataMaxLength | Optional | R | integer |
 | SupportedFeatureProfiles | Required | R | csl :<br>Core<br>FirmwareManagement<br>LocalAuthListManagement<br>RemoteTrigger<br>Reservation<br>SmartCharging |
 | SupportedFeatureProfilesMaxLength | Optional | R | integer |


### PR DESCRIPTION
Corrects three OCPP 1.6 configuration keys in `ocpp/OCPP-1.6-configuration-keys.md` against OCPP 1.6 edition 2 §9.1. `MeterValuesAlignedData`, `StopTxnAlignedData` and `StopTxnSampledData` are now typed **CSL** (were `integer`/`string`), and the two `StopTxn*` keys are marked **RW** (were `R`). The CSL measurand list mirrors the existing `MeterValuesSampledData` row for consistency. A separately reported `HeartBeatInterval` casing issue was a false positive — the file already matches §9.1.10 (`HeartbeatInterval`), so it is left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the OCPP 1.6 configuration key reference for aligned and sampled transaction data.
  * Clarified supported comma-separated measurement values, including energy, power, current, voltage, temperature, frequency, and power factor.
  * Corrected the accessibility information for aligned stop transaction data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->