### PR TITLE
docs(agents): record how to triage a failed refresh run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,11 @@ Enrichment is **incremental**: it loads the committed `classifications.csv` and 
 **Triaging a failed refresh run.** `gh run view <id> --log-failed` shows the tail of the failing step, which for this workflow is the guard reporting a symptom — the cause is in the `enrich` step, hundreds of lines earlier. `gh` does not resolve step names in `--log` output (every line reads `UNKNOWN STEP`), so filter on the message, not the columns:
 
 ```bash
-gh run view <id> --log > /tmp/awesome-ev-charging-<id>.log
-grep -E "\-> \(none\)" /tmp/awesome-ev-charging-<id>.log   # repos that came back uncategorised
-grep -E "readme|classifier (failed|error)" /tmp/awesome-ev-charging-<id>.log
+run_id=33500786084                    # the failing run
+log="/tmp/awesome-ev-charging-$run_id.log"
+gh run view "$run_id" --log > "$log"
+grep -E "\-> \(none\)" "$log"                       # repos that came back uncategorised
+grep -E "readme|classifier (failed|error)" "$log"
 ```
 
 A `⚠️ GitHub request failed: 404 …/readme` immediately above a `(none)` means the repo has no README, which is a fact about the repo; a `⚠️ classifier failed` means the CLI broke, which is a fact about the run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ auto-creates/activates a `.venv` — no manual `source .venv/bin/activate`. Run
 mise install          # install the pinned Python
 mise run install      # (alias: mise run i) runtime deps into .venv
 mise run install-dev  # runtime + pytest; `install` alone keeps the CI data job lean
+#   A fresh .venv has no pytest — run this before `mise run test`, or the suite
+#   fails with "No module named pytest" and it looks like a broken environment.
 mise run test         # (alias: mise run t) pytest
 
 mise run ingest       # Stage 1 -> repos.csv   (wires --token via `gh auth token`)
@@ -94,6 +96,16 @@ Each backend returns `(description, categories)` on success, `("", [])` when the
 Enrichment is **incremental**: it loads the committed `classifications.csv` and reuses a repo's categories while nothing the classifier reads has changed, so re-runs only pay the LLM cost for new or updated repos. The reuse key is `pushed_at` **plus** `classifier_signature` — a hash of the GitHub description, the topics and the README as truncated for the prompt, stored in the `signals` column. `pushed_at` alone was not enough: it only moves on a commit, so a description or topic list edited in the repository settings kept a stale classification indefinitely — and for a repo with no README those two are the *only* inputs. A cache entry written before the column existed carries no signature and is still reused (re-classifying all ~500 repos in one run would not fit the workflow's 30-minute timeout); every entry is stamped as it is rewritten, reused ones included, so the check is live for every repo from the next run on. A failed classification leaves that repo's cache entry unchanged, so the next run retries it on its own; `--refresh` ignores the cache and re-classifies every repo.
 
 **Guarding the classification cache.** `python pipeline.py check-classifications --base -` (reading the baseline `classifications.csv` on stdin) is the monthly workflow's gate before it opens a PR. It compares **per repo, not by count**: a repo that *had* a category and comes back without one is a regression and exits non-zero; a newly discovered repo that arrives without one never had a category to lose, and only warns. Counting empty rows conflated the two and blocked the refresh every time a README-less repo entered the listing.
+
+**Triaging a failed refresh run.** `gh run view <id> --log-failed` shows the tail of the failing step, which for this workflow is the guard reporting a symptom — the cause is in the `enrich` step, hundreds of lines earlier. `gh` does not resolve step names in `--log` output (every line reads `UNKNOWN STEP`), so filter on the message, not the columns:
+
+```bash
+gh run view <id> --log > /tmp/awesome-ev-charging-<id>.log
+grep -E "\-> \(none\)" /tmp/awesome-ev-charging-<id>.log   # repos that came back uncategorised
+grep -E "readme|classifier (failed|error)" /tmp/awesome-ev-charging-<id>.log
+```
+
+A `⚠️ GitHub request failed: 404 …/readme` immediately above a `(none)` means the repo has no README, which is a fact about the repo; a `⚠️ classifier failed` means the CLI broke, which is a fact about the run.
 
 Curation knobs are module-level constants: `TOPICS`, `STARRED_USERS`, `STARRED_LISTS`, `EXCLUDED_REPOS`, `ADDITIONAL_REPOS`, `CATEGORY_TREE`, `CATEGORY_OVERRIDES`, `REPO_OVERRIDES`, `DORMANT_DAYS`, `CLASSIFIER_AGENT`/`CLASSIFIER_MODEL`/`CLASSIFIER_COPILOT_MODEL`.
 


### PR DESCRIPTION
Follow-up to #46, from what diagnosing [run 33500786084](https://github.com/juherr/awesome-ev-charging/actions/runs/33500786084) had to rediscover. Documentation only — no code, no behaviour change.

**A fresh `.venv` has no pytest.** `mise run test` then fails with `No module named pytest`, which reads like a broken environment rather than a missing install step. `install-dev` already existed and is already documented; the note just puts the consequence next to it.

**Triaging a failed refresh run.** `gh run view <id> --log-failed` shows the tail of the failing step — for this workflow, the guard reporting a symptom, while the cause sits in the `enrich` step hundreds of lines earlier. `gh` also labels every `--log` line `UNKNOWN STEP`, so the log has to be filtered on the message rather than the columns. The section records the two greps that get there in one pass, and how to read the result:

- `⚠️ GitHub request failed: 404 …/readme` above a `(none)` — a fact about the repository (it has no README).
- `⚠️ classifier failed` — a fact about the run (the CLI broke).

That distinction is the one #46 turned into code, where the first case is a warning and the second leaves the cache untouched for a retry.

https://claude.ai/code/session_01V9bt6UxvoNH4adUpzPzSdB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that development dependencies must be installed in a fresh virtual environment before running tests.
  - Added guidance for diagnosing failed refresh workflow runs, including capturing and inspecting logs with a run ID.
  - Documented commands for identifying uncategorized repositories and classifier or README failures.
  - Explained how to distinguish repository-level issues, such as a missing README, from run-level classifier failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->