### PR TITLE
chore(deps): refresh the pinned toolchain and dependencies

### DIFF
--- a/.github/workflows/refresh-metadata.yml
+++ b/.github/workflows/refresh-metadata.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up mise (Python 3.11 + venv)
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
       - name: Install Python dependencies
         run: mise run install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up mise (Python 3.11 + venv)
-        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
 
       - name: Install Python dependencies
         run: mise run install-dev

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ The repo also vendors protocol specifications as static assets under `ocpp/`, `o
 
 ## Commands
 
-The project is managed with **mise** (`mise.toml`): it pins Python 3.11.11 and
+The project is managed with **mise** (`mise.toml`): it pins Python 3.11.16 and
 auto-creates/activates a `.venv` — no manual `source .venv/bin/activate`. Run
 `mise trust` once after cloning.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ committed are `classifications.csv`, `README.md`, `legacy-projects.md`,
 
 ### Setup
 
-The project is managed with [mise](https://mise.jdx.dev/) (pins Python 3.11.11 and
+The project is managed with [mise](https://mise.jdx.dev/) (pins Python 3.11.16 and
 auto-creates a `.venv`):
 
 ```bash

--- a/mise.toml
+++ b/mise.toml
@@ -1,11 +1,11 @@
 min_version = "2024.9.5"
 
 [tools]
-python = "3.11.11"
+python = "3.11.16"
 # The install tasks below shell out to `uv`, and the venv has no pip to fall back
 # on. Declaring it here is what makes them work on a bare runner — CI had only
 # ever passed because a developer's machine happened to have uv on PATH.
-uv = "0.12.5"
+uv = "0.12.8"
 
 [env]
 # Auto-create and activate a project virtualenv — no manual `source .venv/bin/activate`.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 # Test-only dependencies. Runtime deps live in requirements.txt; the tests never
 # reach the network, so nothing here is needed to run the pipeline itself.
-pytest==8.4.2
+pytest==9.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2026.7.22
-charset-normalizer==3.4.9
-idna==3.18
+charset-normalizer==3.5.1
+idna==3.19
 requests==2.34.2
 urllib3==2.7.0


### PR DESCRIPTION
Routine refresh of everything this repository pins. No behaviour change.

| What | From | To | Note |
| --- | --- | --- | --- |
| Python (mise) | 3.11.11 | 3.11.16 | patch only, the 3.11 line is unchanged |
| uv (mise) | 0.12.5 | 0.12.8 | patch |
| pytest | 8.4.2 | 9.1.1 | **major** |
| charset-normalizer | 3.4.9 | 3.5.1 | |
| idna | 3.18 | 3.19 | |
| jdx/mise-action | v4.2.4 | v4.3.0 | re-pinned to the tag's SHA |

Already at their latest release, left alone: `certifi`, `requests`, `urllib3`, `actions/checkout` (v7.0.1), `actions/setup-node` (v7.0.0), `peter-evans/create-pull-request` (v8.1.1) — their existing SHA pins already resolve to the latest tag.

## Verification

`.venv` deleted and rebuilt from scratch on the new interpreter, then:

- 86 tests pass on Python 3.11.16 / pytest 9.1.1, with no deprecation warning — the major bump was run, not assumed.
- `pipeline.py` and `csms.py` both import.
- `csms.py render` reproduces the committed `csms.md` and `csms-features.md` byte for byte (empty diff), so the render stayed deterministic across the dependency change.

`AGENTS.md` names the pinned Python version in prose; it moves with `mise.toml`.

https://claude.ai/code/session_01V9bt6UxvoNH4adUpzPzSdB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s managed Python and tooling versions.
  * Refreshed automated workflow tooling for metadata updates and tests.
  * Updated runtime and development dependency versions.

* **Documentation**
  * Updated development guidance to reflect the current Python toolchain version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->